### PR TITLE
Add RAG context lookup before streaming responses

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -4,6 +4,7 @@ import { google } from '@ai-sdk/google';
 import { adminDb } from '@/lib/firebase/admin';
 import { FieldValue } from 'firebase-admin/firestore';
 import { CHAT_SYSTEM_PROMPT } from '@/lib/ai/prompts';
+import { ragSystem } from '@/lib/ai/rag-system';
 
 export async function POST(request: NextRequest) {
   try {
@@ -18,29 +19,59 @@ export async function POST(request: NextRequest) {
     const { messages, chatId: existingChatId } = await request.json();
 
     // Determine the chat ID
-    const chatId = existingChatId || adminDb.collection('companies').doc(companyId).collection('conversations').doc().id;
+    const chatId =
+      existingChatId ||
+      adminDb
+        .collection('companies')
+        .doc(companyId)
+        .collection('conversations')
+        .doc().id;
 
     // Save user message to Firestore
     const userMessage = messages[messages.length - 1];
-    const userMessageRef = adminDb
-      .doc(`companies/${companyId}/conversations/${chatId}/messages/${userMessage.id}`);
-    
+    const userMessageRef = adminDb.doc(
+      `companies/${companyId}/conversations/${chatId}/messages/${userMessage.id}`,
+    );
+
     await userMessageRef.set({
       ...userMessage,
       userId,
       timestamp: FieldValue.serverTimestamp(),
     });
 
+    // Retrieve relevant context from RAG system
+    const searchResults = await ragSystem.search(
+      userMessage.content,
+      companyId,
+    );
+    const context = searchResults
+      .map((result) => result.chunk.content)
+      .join('\n\n');
+    if (searchResults.length > 0) {
+      console.log(
+        'RAG search results:',
+        searchResults.map((r) => ({
+          chunkId: r.chunk.id,
+          documentId: r.chunk.documentId,
+          score: r.score,
+        })),
+      );
+    }
+    const systemPrompt = context
+      ? `Context:\n${context}\n\n${CHAT_SYSTEM_PROMPT}`
+      : CHAT_SYSTEM_PROMPT;
+
     // Call the Google AI model
     const result = await streamText({
       model: google('gemini-1.5-flash-latest'),
-      system: CHAT_SYSTEM_PROMPT,
+      system: systemPrompt,
       messages,
       async onFinish({ text, toolCalls, toolResults, usage, finishReason }) {
         // Save assistant message to Firestore
-        const assistantMessageRef = adminDb
-          .doc(`companies/${companyId}/conversations/${chatId}/messages/ai-message-${Date.now()}`);
-        
+        const assistantMessageRef = adminDb.doc(
+          `companies/${companyId}/conversations/${chatId}/messages/ai-message-${Date.now()}`,
+        );
+
         await assistantMessageRef.set({
           role: 'assistant',
           content: text || null,
@@ -53,16 +84,18 @@ export async function POST(request: NextRequest) {
         });
 
         // Update the conversation metadata
-        await adminDb.doc(`companies/${companyId}/conversations/${chatId}`).set({
-          userId,
-          updatedAt: FieldValue.serverTimestamp(),
-          lastMessage: text ? text.substring(0, 100) : '[AI Response]',
-        }, { merge: true });
+        await adminDb.doc(`companies/${companyId}/conversations/${chatId}`).set(
+          {
+            userId,
+            updatedAt: FieldValue.serverTimestamp(),
+            lastMessage: text ? text.substring(0, 100) : '[AI Response]',
+          },
+          { merge: true },
+        );
       },
     });
 
     return result.toDataStreamResponse();
-
   } catch (error) {
     console.error('Chat API error:', error);
     return new NextResponse('Internal Server Error', { status: 500 });


### PR DESCRIPTION
## Summary
- Fetch relevant document chunks via `ragSystem.search` using the latest user message
- Prepend retrieved context to chat system prompt and log chunk IDs for traceability

## Testing
- `pnpm biome check app/api/chat/route.ts`
- `npx next lint --file app/api/chat/route.ts` *(fails: Couldn't find any `pages` or `app` directory)*
- `pnpm test` *(fails: No "sendPasswordResetEmail" export is defined on the "firebase/auth" mock)*
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b9dae7b328833185fe32a99d791ede