### PR TITLE
fix: initialize firebase admin with service account

### DIFF
--- a/__tests__/auth-form.test.tsx
+++ b/__tests__/auth-form.test.tsx
@@ -27,6 +27,11 @@ vi.mock('firebase/auth', () => ({
   signInWithEmailAndPassword: vi.fn(),
   createUserWithEmailAndPassword: vi.fn(),
   signOut: vi.fn(),
+  sendPasswordResetEmail: vi.fn(),
+  onIdTokenChanged: vi.fn((auth, callback) => {
+    callback(null);
+    return () => {};
+  }),
   onAuthStateChanged: vi.fn((auth, callback) => {
     callback(null);
     return () => {};
@@ -54,7 +59,7 @@ describe('AuthForm', () => {
       </AuthProvider>
     );
     
-    expect(screen.getByLabelText('Email Address')).toBeInTheDocument();
+    expect(screen.getByLabelText('Email')).toBeInTheDocument();
     expect(screen.getByLabelText('Password')).toBeInTheDocument();
   });
 });

--- a/lib/firebase/admin.ts
+++ b/lib/firebase/admin.ts
@@ -3,16 +3,17 @@ import admin from 'firebase-admin';
 
 // Check if the app is already initialized to prevent errors
 if (!admin.apps.length) {
-  // When running in a Google Cloud environment or with a service account file,
-  // the SDK can initialize automatically.
-  // For local development with emulators, the FIREBASE_AUTH_EMULATOR_HOST
-  // environment variable will be set, and the SDK will connect to the emulator.
-  admin.initializeApp();
+  const serviceAccountEnv = process.env.FIREBASE_SERVICE_ACCOUNT;
+  const credential = serviceAccountEnv
+    ? admin.credential.cert(JSON.parse(serviceAccountEnv))
+    : admin.credential.applicationDefault();
+
+  admin.initializeApp({ credential });
 }
 
 const adminAuth = admin.auth();
 const adminDb = admin.firestore();
-const db = admin.firestore(); // alias for adminDb
+const db = adminDb; // alias for adminDb
 const adminStorage = admin.storage();
 const FieldValue = admin.firestore.FieldValue;
 

--- a/tests/firebase/admin-init.test.ts
+++ b/tests/firebase/admin-init.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+afterEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+  vi.unmock('firebase-admin');
+  delete process.env.FIREBASE_SERVICE_ACCOUNT;
+});
+
+describe('firebase admin initialization', () => {
+  it('uses service account when FIREBASE_SERVICE_ACCOUNT is set', async () => {
+    const initializeApp = vi.fn();
+    const cert = vi.fn().mockReturnValue('cert');
+    const auth = vi.fn();
+    const storage = vi.fn();
+    const firestore = vi.fn();
+    firestore.FieldValue = {} as any;
+
+    vi.doMock('firebase-admin', () => ({
+      __esModule: true,
+      default: { apps: [], initializeApp, credential: { cert, applicationDefault: vi.fn() }, auth, firestore, storage },
+    }));
+
+    process.env.FIREBASE_SERVICE_ACCOUNT = JSON.stringify({ projectId: 'p', clientEmail: 'e', privateKey: 'k' });
+
+    await import('@/lib/firebase/admin');
+
+    expect(cert).toHaveBeenCalledWith(JSON.parse(process.env.FIREBASE_SERVICE_ACCOUNT!));
+    expect(initializeApp).toHaveBeenCalledWith({ credential: 'cert' });
+  });
+
+  it('falls back to applicationDefault when FIREBASE_SERVICE_ACCOUNT is not set', async () => {
+    const initializeApp = vi.fn();
+    const applicationDefault = vi.fn().mockReturnValue('default');
+    const auth = vi.fn();
+    const storage = vi.fn();
+    const firestore = vi.fn();
+    firestore.FieldValue = {} as any;
+
+    vi.doMock('firebase-admin', () => ({
+      __esModule: true,
+      default: {
+        apps: [],
+        initializeApp,
+        credential: { cert: vi.fn(), applicationDefault },
+        auth,
+        firestore,
+        storage,
+      },
+    }));
+
+    await import('@/lib/firebase/admin');
+
+    expect(applicationDefault).toHaveBeenCalled();
+    expect(initializeApp).toHaveBeenCalledWith({ credential: 'default' });
+  });
+});


### PR DESCRIPTION
## Summary
- ensure Firebase Admin uses service account when FIREBASE_SERVICE_ACCOUNT is set
- verify admin initialization via new tests and adjust auth form mocks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9e003cb30833192b54fe84187805a