### PR TITLE
feat: remove vertex vectors on document deletion

### DIFF
--- a/app/api/admin/companies/[companyId]/documents/[documentId]/route.ts
+++ b/app/api/admin/companies/[companyId]/documents/[documentId]/route.ts
@@ -21,7 +21,7 @@ export const DELETE = withAuth(
       }
 
       // 2. Delete vectors from the vector database
-      await deleteDocumentVectors(documentId);
+      await deleteDocumentVectors(companyId, documentId);
 
       // 3. Delete the document record from Firestore
       await documentService.deleteDocument(companyId, documentId);


### PR DESCRIPTION
## Summary
- add helper to remove document chunk vectors from Vertex AI and Firestore
- wire company document delete route to call vector cleanup

## Testing
- `pnpm test`
- `pnpm lint` *(fails: Formatter would have printed content / Some errors emitted while running checks)*
- `pnpm typecheck` *(fails: TS2345/TS2339 errors in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b98284e4048331b7a41af9b2c7bddb