### PR TITLE
feat: upsert document chunks to vector search

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -18,7 +18,9 @@
     "@google/generative-ai": "^0.21.0",
     "firebase-admin": "^12.6.0",
     "firebase-functions": "^6.0.1",
-    "pdf-parse": "^1.1.1"
+    "pdf-parse": "^1.1.1",
+    "@google-cloud/aiplatform": "^5.5.0",
+    "@google-cloud/vertexai": "^1.10.0"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.12.0",

--- a/functions/pnpm-lock.yaml
+++ b/functions/pnpm-lock.yaml
@@ -8,6 +8,12 @@ importers:
 
   .:
     dependencies:
+      '@google-cloud/aiplatform':
+        specifier: ^5.5.0
+        version: 5.6.0
+      '@google-cloud/vertexai':
+        specifier: ^1.10.0
+        version: 1.10.0
       '@google/generative-ai':
         specifier: ^0.21.0
         version: 0.21.0
@@ -271,6 +277,10 @@ packages:
   '@firebase/util@1.10.0':
     resolution: {integrity: sha512-xKtx4A668icQqoANRxyDLBLz51TAbDP9KRfpbKGxiCAW346d0BeJe5vN6/hKxxmWwnZ0mautyv39JxviwwQMOQ==}
 
+  '@google-cloud/aiplatform@5.6.0':
+    resolution: {integrity: sha512-L4rQXfjVTQbhVWt4WS+RQNBmcREpiEM8owceVsSV4i3AIh9wbd078Quiupl9Uce9qQNGag0V7HGVbAuT5BZNmw==}
+    engines: {node: '>=18'}
+
   '@google-cloud/firestore@7.11.3':
     resolution: {integrity: sha512-qsM3/WHpawF07SRVvEJJVRwhYzM7o9qtuksyuqnrMig6fxIrwWnsezECWsG/D5TyYru51Fv5c/RTqNDQ2yU+4w==}
     engines: {node: '>=14.0.0'}
@@ -291,6 +301,10 @@ packages:
     resolution: {integrity: sha512-5m9GoZqKh52a1UqkxDBu/+WVFDALNtHg5up5gNmNbXQWBcV813tzJKsyDtKjOPrlR1em1TxtD7NSPCrObH7koQ==}
     engines: {node: '>=14'}
 
+  '@google-cloud/vertexai@1.10.0':
+    resolution: {integrity: sha512-HqYqoivNtkq59po8m7KI0n+lWKdz4kabENncYQXZCX/hBWJfXtKAfR/2nUQsP+TwSfHKoA7zDL2RrJYIv/j3VQ==}
+    engines: {node: '>=18.0.0'}
+
   '@google/generative-ai@0.21.0':
     resolution: {integrity: sha512-7XhUbtnlkSEZK15kN3t+tzIMxsbKm/dSkKBFalj+20NvPKe1kBY7mR2P7vuijEn+f06z5+A8bVGKO0v39cr6Wg==}
     engines: {node: '>=18.0.0'}
@@ -301,6 +315,11 @@ packages:
 
   '@grpc/proto-loader@0.7.15':
     resolution: {integrity: sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  '@grpc/proto-loader@0.8.0':
+    resolution: {integrity: sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==}
     engines: {node: '>=6'}
     hasBin: true
 
@@ -1029,6 +1048,10 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
+
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
     engines: {node: '>= 0.4'}
@@ -1348,6 +1371,10 @@ packages:
   fb-watchman@2.0.2:
     resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
 
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+
   file-entry-cache@6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -1406,6 +1433,10 @@ packages:
     resolution: {integrity: sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==}
     engines: {node: '>= 0.12'}
 
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
+
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
@@ -1439,9 +1470,17 @@ packages:
     resolution: {integrity: sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==}
     engines: {node: '>=14'}
 
+  gaxios@7.1.1:
+    resolution: {integrity: sha512-Odju3uBUJyVCkW64nLD4wKLhbh93bh6vIg/ZIXkWiLPBrdgtc65+tls/qml+un3pr6JqYVFDZbbmLDQT68rTOQ==}
+    engines: {node: '>=18'}
+
   gcp-metadata@6.1.1:
     resolution: {integrity: sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==}
     engines: {node: '>=14'}
+
+  gcp-metadata@7.0.1:
+    resolution: {integrity: sha512-UcO3kefx6dCcZkgcTGgVOTFb7b1LlQ02hY1omMjjrrBzkajRMCFgYOjs7J71WqnuG1k2b+9ppGL7FsOfhZMQKQ==}
+    engines: {node: '>=18'}
 
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -1499,6 +1538,10 @@ packages:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
 
+  google-auth-library@10.3.0:
+    resolution: {integrity: sha512-ylSE3RlCRZfZB56PFJSfUCuiuPq83Fx8hqu1KPWGK8FVdSaxlp/qkeMMX/DT/18xkwXIHvXEXkZsljRwfrdEfQ==}
+    engines: {node: '>=18'}
+
   google-auth-library@9.15.1:
     resolution: {integrity: sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==}
     engines: {node: '>=14'}
@@ -1507,8 +1550,16 @@ packages:
     resolution: {integrity: sha512-V6eky/xz2mcKfAd1Ioxyd6nmA61gao3n01C+YeuIwu3vzM9EDR6wcVzMSIbLMDXWeoi9SHYctXuKYC5uJUT3eQ==}
     engines: {node: '>=14'}
 
+  google-gax@5.0.3:
+    resolution: {integrity: sha512-DkWybwgkV8HA9aIizNEHEUHd8ho1BzGGQ/YMGDsTt167dQ8pk/oMiwxpUFvh6Ta93m8ZN7KwdWmP3o46HWjV+A==}
+    engines: {node: '>=18'}
+
   google-logging-utils@0.0.2:
     resolution: {integrity: sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==}
+    engines: {node: '>=14'}
+
+  google-logging-utils@1.1.1:
+    resolution: {integrity: sha512-rcX58I7nqpu4mbKztFeOAObbomBbHU2oIb/d3tJfF3dizGSApqtSwYJigGCooHdnMyQBIw8BrWyK96w3YXgr6A==}
     engines: {node: '>=14'}
 
   gopd@1.2.0:
@@ -1524,6 +1575,10 @@ packages:
   gtoken@7.1.0:
     resolution: {integrity: sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==}
     engines: {node: '>=14.0.0'}
+
+  gtoken@8.0.0:
+    resolution: {integrity: sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==}
+    engines: {node: '>=18'}
 
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
@@ -2120,6 +2175,11 @@ packages:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
     engines: {node: '>= 0.6'}
 
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
   node-ensure@0.0.0:
     resolution: {integrity: sha512-DRI60hzo2oKN1ma0ckc6nQWlHU69RH6xN0sjQTjMpChPfTYvKZdcQFfdYK2RWbJcKyUizSIy/l8OTGxMAM1QDw==}
 
@@ -2131,6 +2191,10 @@ packages:
     peerDependenciesMeta:
       encoding:
         optional: true
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   node-forge@1.3.1:
     resolution: {integrity: sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==}
@@ -2301,6 +2365,10 @@ packages:
     resolution: {integrity: sha512-SAzp/O4Yh02jGdRc+uIrGoe87dkN/XtwxfZ4ZyafJHymd79ozp5VG5nyZ7ygqPM5+cpLDjjGnYFUkngonyDPOQ==}
     engines: {node: '>=14.0.0'}
 
+  proto3-json-serializer@3.0.2:
+    resolution: {integrity: sha512-AnMIfnoK2Ml3F/ZVl5PxcwIoefMxj4U/lomJ5/B2eIGdxw4UkbV1YamtsMQsEkZATdMCKMbnI1iG9RQaJbxBGw==}
+    engines: {node: '>=18'}
+
   protobufjs@7.5.4:
     resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
     engines: {node: '>=12.0.0'}
@@ -2370,6 +2438,10 @@ packages:
   retry-request@7.0.2:
     resolution: {integrity: sha512-dUOvLMJ0/JJYEn8NrpOaGNE7X3vpI5XlZS/u0ANjqtcZVKnIxP7IgCFwrKTxENw29emmwug53awKtaMm4i9g5w==}
     engines: {node: '>=14'}
+
+  retry-request@8.0.2:
+    resolution: {integrity: sha512-JzFPAfklk1kjR1w76f0QOIhoDkNkSqW8wYKT08n9yysTmZfB+RQ2QoXoTAeOi1HD9ZipTyTAZg3c4pM/jeqgSw==}
+    engines: {node: '>=18'}
 
   retry@0.13.1:
     resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
@@ -2573,6 +2645,10 @@ packages:
     resolution: {integrity: sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw==}
     engines: {node: ^14.18.0 || >=16.0.0}
 
+  teeny-request@10.1.0:
+    resolution: {integrity: sha512-3ZnLvgWF29jikg1sAQ1g0o+lr5JX6sVgYvfUJazn7ZjJroDBUTWp44/+cFVX0bULjv4vci+rBD+oGVAkWqhUbw==}
+    engines: {node: '>=18'}
+
   teeny-request@9.0.0:
     resolution: {integrity: sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g==}
     engines: {node: '>=14'}
@@ -2712,6 +2788,10 @@ packages:
 
   walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
+
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -3069,6 +3149,12 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@google-cloud/aiplatform@5.6.0':
+    dependencies:
+      google-gax: 5.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@google-cloud/firestore@7.11.3':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -3115,13 +3201,19 @@ snapshots:
       - supports-color
     optional: true
 
+  '@google-cloud/vertexai@1.10.0':
+    dependencies:
+      google-auth-library: 9.15.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
   '@google/generative-ai@0.21.0': {}
 
   '@grpc/grpc-js@1.13.4':
     dependencies:
       '@grpc/proto-loader': 0.7.15
       '@js-sdsl/ordered-map': 4.4.2
-    optional: true
 
   '@grpc/proto-loader@0.7.15':
     dependencies:
@@ -3129,7 +3221,13 @@ snapshots:
       long: 5.3.2
       protobufjs: 7.5.4
       yargs: 17.7.2
-    optional: true
+
+  '@grpc/proto-loader@0.8.0':
+    dependencies:
+      lodash.camelcase: 4.3.0
+      long: 5.3.2
+      protobufjs: 7.5.4
+      yargs: 17.7.2
 
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
@@ -3355,8 +3453,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@js-sdsl/ordered-map@4.4.2':
-    optional: true
+  '@js-sdsl/ordered-map@4.4.2': {}
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
@@ -3420,8 +3517,7 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
-  '@tootallnate/once@2.0.0':
-    optional: true
+  '@tootallnate/once@2.0.0': {}
 
   '@tybys/wasm-util@0.10.0':
     dependencies:
@@ -3701,7 +3797,6 @@ snapshots:
   abort-controller@3.0.0:
     dependencies:
       event-target-shim: 5.0.1
-    optional: true
 
   accepts@1.3.8:
     dependencies:
@@ -3719,10 +3814,8 @@ snapshots:
       debug: 4.4.1
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
-  agent-base@7.1.4:
-    optional: true
+  agent-base@7.1.4: {}
 
   ajv@6.12.6:
     dependencies:
@@ -3885,11 +3978,9 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
-  base64-js@1.5.1:
-    optional: true
+  base64-js@1.5.1: {}
 
-  bignumber.js@9.3.1:
-    optional: true
+  bignumber.js@9.3.1: {}
 
   body-parser@1.20.3:
     dependencies:
@@ -4020,6 +4111,8 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  data-uri-to-buffer@4.0.1: {}
+
   data-view-buffer@1.0.2:
     dependencies:
       call-bound: 1.0.4
@@ -4101,7 +4194,6 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
       stream-shift: 1.0.3
-    optional: true
 
   eastasianwidth@0.2.0: {}
 
@@ -4126,7 +4218,6 @@ snapshots:
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
-    optional: true
 
   error-ex@1.3.2:
     dependencies:
@@ -4352,8 +4443,7 @@ snapshots:
 
   etag@1.8.1: {}
 
-  event-target-shim@5.0.1:
-    optional: true
+  event-target-shim@5.0.1: {}
 
   execa@5.1.1:
     dependencies:
@@ -4414,8 +4504,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  extend@3.0.2:
-    optional: true
+  extend@3.0.2: {}
 
   farmhash-modern@1.1.0: {}
 
@@ -4449,6 +4538,11 @@ snapshots:
   fb-watchman@2.0.2:
     dependencies:
       bser: 2.1.1
+
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
 
   file-entry-cache@6.0.1:
     dependencies:
@@ -4545,6 +4639,10 @@ snapshots:
       safe-buffer: 5.2.1
     optional: true
 
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
+
   forwarded@0.2.0: {}
 
   fresh@0.5.2: {}
@@ -4580,7 +4678,14 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
-    optional: true
+
+  gaxios@7.1.1:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - supports-color
 
   gcp-metadata@6.1.1:
     dependencies:
@@ -4590,7 +4695,14 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
-    optional: true
+
+  gcp-metadata@7.0.1:
+    dependencies:
+      gaxios: 7.1.1
+      google-logging-utils: 1.1.1
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   gensync@1.0.0-beta.2: {}
 
@@ -4668,6 +4780,18 @@ snapshots:
       merge2: 1.4.1
       slash: 3.0.0
 
+  google-auth-library@10.3.0:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.1.1
+      gcp-metadata: 7.0.1
+      google-logging-utils: 1.1.1
+      gtoken: 8.0.0
+      jws: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   google-auth-library@9.15.1:
     dependencies:
       base64-js: 1.5.1
@@ -4679,7 +4803,6 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
-    optional: true
 
   google-gax@4.6.1:
     dependencies:
@@ -4700,8 +4823,25 @@ snapshots:
       - supports-color
     optional: true
 
-  google-logging-utils@0.0.2:
-    optional: true
+  google-gax@5.0.3:
+    dependencies:
+      '@grpc/grpc-js': 1.13.4
+      '@grpc/proto-loader': 0.8.0
+      abort-controller: 3.0.0
+      duplexify: 4.1.3
+      google-auth-library: 10.3.0
+      google-logging-utils: 1.1.1
+      node-fetch: 3.3.2
+      object-hash: 3.0.0
+      proto3-json-serializer: 3.0.2
+      protobufjs: 7.5.4
+      retry-request: 8.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  google-logging-utils@0.0.2: {}
+
+  google-logging-utils@1.1.1: {}
 
   gopd@1.2.0: {}
 
@@ -4716,7 +4856,13 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
-    optional: true
+
+  gtoken@8.0.0:
+    dependencies:
+      gaxios: 7.1.1
+      jws: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   has-bigints@1.1.0: {}
 
@@ -4762,7 +4908,6 @@ snapshots:
       debug: 4.4.1
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   https-proxy-agent@5.0.1:
     dependencies:
@@ -4770,7 +4915,6 @@ snapshots:
       debug: 4.4.1
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   https-proxy-agent@7.0.6:
     dependencies:
@@ -4778,7 +4922,6 @@ snapshots:
       debug: 4.4.1
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   human-signals@2.1.0: {}
 
@@ -5302,7 +5445,6 @@ snapshots:
   json-bigint@1.0.0:
     dependencies:
       bignumber.js: 9.3.1
-    optional: true
 
   json-buffer@3.0.1: {}
 
@@ -5342,7 +5484,6 @@ snapshots:
       buffer-equal-constant-time: 1.0.1
       ecdsa-sig-formatter: 1.0.11
       safe-buffer: 5.2.1
-    optional: true
 
   jwks-rsa@3.2.0:
     dependencies:
@@ -5364,7 +5505,6 @@ snapshots:
     dependencies:
       jwa: 2.0.1
       safe-buffer: 5.2.1
-    optional: true
 
   keyv@4.5.4:
     dependencies:
@@ -5389,8 +5529,7 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
-  lodash.camelcase@4.3.0:
-    optional: true
+  lodash.camelcase@4.3.0: {}
 
   lodash.clonedeep@4.5.0: {}
 
@@ -5491,12 +5630,19 @@ snapshots:
 
   negotiator@0.6.3: {}
 
+  node-domexception@1.0.0: {}
+
   node-ensure@0.0.0: {}
 
   node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
-    optional: true
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
 
   node-forge@1.3.1: {}
 
@@ -5512,8 +5658,7 @@ snapshots:
 
   object-assign@4.1.1: {}
 
-  object-hash@3.0.0:
-    optional: true
+  object-hash@3.0.0: {}
 
   object-inspect@1.13.4: {}
 
@@ -5659,6 +5804,10 @@ snapshots:
       protobufjs: 7.5.4
     optional: true
 
+  proto3-json-serializer@3.0.2:
+    dependencies:
+      protobufjs: 7.5.4
+
   protobufjs@7.5.4:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
@@ -5705,7 +5854,6 @@ snapshots:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
-    optional: true
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -5752,6 +5900,13 @@ snapshots:
       - encoding
       - supports-color
     optional: true
+
+  retry-request@8.0.2:
+    dependencies:
+      extend: 3.0.2
+      teeny-request: 10.1.0
+    transitivePeerDependencies:
+      - supports-color
 
   retry@0.13.1:
     optional: true
@@ -5907,10 +6062,8 @@ snapshots:
   stream-events@1.0.5:
     dependencies:
       stubs: 3.0.0
-    optional: true
 
-  stream-shift@1.0.3:
-    optional: true
+  stream-shift@1.0.3: {}
 
   string-length@4.0.2:
     dependencies:
@@ -5955,7 +6108,6 @@ snapshots:
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
-    optional: true
 
   strip-ansi@6.0.1:
     dependencies:
@@ -5976,8 +6128,7 @@ snapshots:
   strnum@1.1.2:
     optional: true
 
-  stubs@3.0.0:
-    optional: true
+  stubs@3.0.0: {}
 
   supports-color@7.2.0:
     dependencies:
@@ -5992,6 +6143,15 @@ snapshots:
   synckit@0.11.11:
     dependencies:
       '@pkgr/core': 0.2.9
+
+  teeny-request@10.1.0:
+    dependencies:
+      http-proxy-agent: 5.0.0
+      https-proxy-agent: 5.0.1
+      node-fetch: 3.3.2
+      stream-events: 1.0.5
+    transitivePeerDependencies:
+      - supports-color
 
   teeny-request@9.0.0:
     dependencies:
@@ -6021,8 +6181,7 @@ snapshots:
 
   toidentifier@1.0.1: {}
 
-  tr46@0.0.3:
-    optional: true
+  tr46@0.0.3: {}
 
   ts-deepmerge@2.0.7: {}
 
@@ -6139,8 +6298,7 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  util-deprecate@1.0.2:
-    optional: true
+  util-deprecate@1.0.2: {}
 
   utils-merge@1.0.1: {}
 
@@ -6149,8 +6307,7 @@ snapshots:
   uuid@8.3.2:
     optional: true
 
-  uuid@9.0.1:
-    optional: true
+  uuid@9.0.1: {}
 
   v8-to-istanbul@9.3.0:
     dependencies:
@@ -6164,8 +6321,9 @@ snapshots:
     dependencies:
       makeerror: 1.0.12
 
-  webidl-conversions@3.0.1:
-    optional: true
+  web-streams-polyfill@3.3.3: {}
+
+  webidl-conversions@3.0.1: {}
 
   websocket-driver@0.7.4:
     dependencies:
@@ -6179,7 +6337,6 @@ snapshots:
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
-    optional: true
 
   which-boxed-primitive@1.1.1:
     dependencies:

--- a/functions/src/process-document.ts
+++ b/functions/src/process-document.ts
@@ -3,8 +3,11 @@ import { adminDb, adminStorage } from './firebase-admin';
 import { FieldValue } from 'firebase-admin/firestore';
 import * as pdf from 'pdf-parse';
 import * as mammoth from 'mammoth';
+import { generateEmbeddings } from '../../lib/ai/embeddings';
+import { vectorSearchService } from '../../lib/ai/vector-search';
 
-const BUCKET_NAME = process.env.GCLOUD_STORAGE_BUCKET || 'your-default-bucket-name';
+const BUCKET_NAME =
+  process.env.GCLOUD_STORAGE_BUCKET || 'your-default-bucket-name';
 
 async function getTextFromPdf(fileBuffer: Buffer): Promise<string> {
   const data = await pdf(fileBuffer);
@@ -16,81 +19,125 @@ async function getTextFromDocx(fileBuffer: Buffer): Promise<string> {
   return value;
 }
 
-export const processDocumentOnUpload = functions.storage.object().onFinalize(async (object) => {
-  const { bucket, name: filePath, contentType } = object;
+export const processDocumentOnUpload = functions.storage
+  .object()
+  .onFinalize(async (object) => {
+    const { bucket, name: filePath, contentType } = object;
 
-  if (!filePath || !contentType) {
-    console.log('File path or content type is missing.');
-    return;
-  }
-  
-  // For this project, we only care about documents in the 'documents' folder
-  if (!filePath.startsWith('documents/')) {
-    console.log(`File ${filePath} is not in a 'documents' folder, skipping.`);
-    return;
-  }
-
-  // Find the corresponding document in Firestore
-  const documentsRef = adminDb.collection('documents');
-  const snapshot = await documentsRef.where('storagePath', '==', filePath).limit(1).get();
-
-  if (snapshot.empty) {
-    console.error(`No Firestore document found for storage path: ${filePath}`);
-    return;
-  }
-  const documentRef = snapshot.docs[0].ref;
-  const documentId = documentRef.id;
-
-  try {
-    console.log(`Processing document ${documentId} for file: ${filePath}`);
-    await documentRef.update({ status: 'processing', updatedAt: FieldValue.serverTimestamp() });
-
-    const fileBuffer = await adminStorage.bucket(bucket).file(filePath).download();
-    let content = '';
-
-    if (contentType === 'application/pdf') {
-      content = await getTextFromPdf(fileBuffer[0]);
-    } else if (contentType === 'application/vnd.openxmlformats-officedocument.wordprocessingml.document') {
-      content = await getTextFromDocx(fileBuffer[0]);
-    } else {
-      console.warn(`Unsupported content type: ${contentType}. Skipping.`);
-      await documentRef.update({ status: 'failed', error: 'Unsupported file type', updatedAt: FieldValue.serverTimestamp() });
+    if (!filePath || !contentType) {
+      console.log('File path or content type is missing.');
       return;
     }
 
-    if (!content || content.trim().length === 0) {
-      throw new Error('No content extracted from the document.');
+    // For this project, we only care about documents in the 'documents' folder
+    if (!filePath.startsWith('documents/')) {
+      console.log(`File ${filePath} is not in a 'documents' folder, skipping.`);
+      return;
     }
 
-    // Simple chunking strategy
-    const chunks = content.match(/.{1,1500}/gs) || [];
-    const chunksCollectionRef = documentRef.collection('content_chunks');
-    const batch = adminDb.batch();
+    // Find the corresponding document in Firestore
+    const documentsRef = adminDb.collection('documents');
+    const snapshot = await documentsRef
+      .where('storagePath', '==', filePath)
+      .limit(1)
+      .get();
 
-    chunks.forEach((chunk, index) => {
-      const chunkRef = chunksCollectionRef.doc(`chunk_${index}`);
-      batch.set(chunkRef, {
-        content: chunk,
-        chunkNumber: index + 1,
-        charCount: chunk.length,
+    if (snapshot.empty) {
+      console.error(
+        `No Firestore document found for storage path: ${filePath}`,
+      );
+      return;
+    }
+    const documentDoc = snapshot.docs[0];
+    const documentRef = documentDoc.ref;
+    const documentId = documentRef.id;
+    const companyId = documentDoc.get('companyId');
+
+    try {
+      console.log(`Processing document ${documentId} for file: ${filePath}`);
+      await documentRef.update({
+        status: 'processing',
+        updatedAt: FieldValue.serverTimestamp(),
       });
-    });
-    await batch.commit();
 
-    await documentRef.update({
-      status: 'processed',
-      chunkCount: chunks.length,
-      totalCharCount: content.length,
-      updatedAt: FieldValue.serverTimestamp(),
-    });
+      const fileBuffer = await adminStorage
+        .bucket(bucket)
+        .file(filePath)
+        .download();
+      let content = '';
 
-    console.log(`[SUCCESS] Stored ${chunks.length} chunks for document ${documentId}`);
-  } catch (error) {
-    console.error(`[FAIL] Could not process document ${documentId}:`, error);
-    await documentRef.update({
-      status: 'failed',
-      error: (error as Error).message,
-      updatedAt: FieldValue.serverTimestamp(),
-    }).catch(err => console.error(`Failed to update document status to "failed":`, err));
-  }
-});
+      if (contentType === 'application/pdf') {
+        content = await getTextFromPdf(fileBuffer[0]);
+      } else if (
+        contentType ===
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+      ) {
+        content = await getTextFromDocx(fileBuffer[0]);
+      } else {
+        console.warn(`Unsupported content type: ${contentType}. Skipping.`);
+        await documentRef.update({
+          status: 'failed',
+          error: 'Unsupported file type',
+          updatedAt: FieldValue.serverTimestamp(),
+        });
+        return;
+      }
+
+      if (!content || content.trim().length === 0) {
+        throw new Error('No content extracted from the document.');
+      }
+
+      // Simple chunking strategy
+      const chunks = content.match(/.{1,1500}/gs) || [];
+      const chunksCollectionRef = documentRef.collection('content_chunks');
+      const batch = adminDb.batch();
+
+      chunks.forEach((chunk, index) => {
+        const chunkId = `${documentId}_chunk_${index}`;
+        const chunkRef = chunksCollectionRef.doc(chunkId);
+        batch.set(chunkRef, {
+          id: chunkId,
+          content: chunk,
+          chunkNumber: index + 1,
+          charCount: chunk.length,
+        });
+      });
+      await batch.commit();
+
+      if (companyId) {
+        const embeddings = await generateEmbeddings(chunks);
+        const upsertPayload = embeddings.map((embedding, index) => ({
+          id: `${documentId}_chunk_${index}`,
+          embedding,
+          companyId,
+        }));
+        await vectorSearchService.upsertChunks(upsertPayload);
+      } else {
+        console.warn(
+          `No companyId found for document ${documentId}; skipping vector upsert.`,
+        );
+      }
+
+      await documentRef.update({
+        status: 'processed',
+        chunkCount: chunks.length,
+        totalCharCount: content.length,
+        updatedAt: FieldValue.serverTimestamp(),
+      });
+
+      console.log(
+        `[SUCCESS] Stored ${chunks.length} chunks for document ${documentId}`,
+      );
+    } catch (error) {
+      console.error(`[FAIL] Could not process document ${documentId}:`, error);
+      await documentRef
+        .update({
+          status: 'failed',
+          error: (error as Error).message,
+          updatedAt: FieldValue.serverTimestamp(),
+        })
+        .catch((err) =>
+          console.error(`Failed to update document status to "failed":`, err),
+        );
+    }
+  });

--- a/lib/ai/vector-search.ts
+++ b/lib/ai/vector-search.ts
@@ -44,10 +44,13 @@ class VectorSearchService {
     return `projects/${PROJECT_ID}/locations/${LOCATION}/indexEndpoints/${INDEX_ENDPOINT_ID}`;
   }
 
-  async upsertChunks(chunks: { id: string; embedding: number[] }[]) {
+  async upsertChunks(
+    chunks: { id: string; embedding: number[]; companyId: string }[],
+  ) {
     const datapoints = chunks.map((chunk) => ({
       datapointId: chunk.id,
       featureVector: chunk.embedding,
+      restricts: [{ namespace: 'company_id', allowTokens: [chunk.companyId] }],
     }));
 
     const request = {
@@ -55,13 +58,34 @@ class VectorSearchService {
       datapoints,
     };
 
-    try {
-      console.log('Upserting datapoints to Vertex AI Vector Search...');
-      await this.indexClient.upsertDatapoints(request);
-      console.log('Successfully upserted datapoints.');
-    } catch (error) {
-      console.error('Error upserting datapoints to Vertex AI:', error);
-      throw new Error('Could not update the vector search index.');
+    const maxRetries = 3;
+
+    for (let attempt = 1; attempt <= maxRetries; attempt++) {
+      try {
+        console.log('Upserting datapoints to Vertex AI Vector Search...');
+        await this.indexClient.upsertDatapoints(request);
+        console.log('Successfully upserted datapoints.');
+        return;
+      } catch (error: any) {
+        const networkErrors = [
+          'ECONNRESET',
+          'ETIMEDOUT',
+          'EAI_AGAIN',
+          'ENOTFOUND',
+        ];
+        const isNetworkError = networkErrors.includes(error?.code);
+
+        if (!isNetworkError || attempt === maxRetries) {
+          console.error('Error upserting datapoints to Vertex AI:', error);
+          throw new Error('Could not update the vector search index.');
+        }
+
+        const delay = Math.pow(2, attempt - 1) * 1000;
+        console.warn(
+          `Network error during upsert, retrying in ${delay}ms (attempt ${attempt})`,
+        );
+        await new Promise((resolve) => setTimeout(resolve, delay));
+      }
     }
   }
 
@@ -183,6 +207,7 @@ export async function upsertDocumentChunks(
       const slice = chunks.slice(i, i + 100).map((chunk, idx) => ({
         id: chunk.id,
         embedding: embeddings[i + idx],
+        companyId,
       }));
       if (slice.length > 0) {
         await vectorSearchService.upsertChunks(slice);


### PR DESCRIPTION
## Summary
- add Vertex AI upsert logic to document processing Cloud Function
- include companyId in datapoint restricts for isolation
- retry vector upserts on network errors

## Testing
- `pnpm lint` *(fails: Formatter would have printed the following content)*
- `pnpm biome check lib/ai/vector-search.ts lib/ai/rag-system.ts functions/src/process-document.ts`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9ea53b704833183974c4cfe09d6ab