### PR TITLE
feat(auth): enforce token and role validation

### DIFF
--- a/app/api/auth/verify-token/route.ts
+++ b/app/api/auth/verify-token/route.ts
@@ -1,0 +1,45 @@
+import { type NextRequest, NextResponse } from 'next/server';
+import { adminAuth } from '@/lib/firebase/admin';
+import { normalizeLegacyRole, USER_ROLES } from '@/lib/constants/roles';
+
+/**
+ * POST /api/auth/verify-token
+ * Verifies a Firebase ID token and returns normalized user information.
+ */
+export async function POST(req: NextRequest) {
+  try {
+    const { idToken } = await req.json();
+
+    if (!idToken) {
+      return NextResponse.json({ error: 'ID token required' }, { status: 400 });
+    }
+
+    try {
+      const decoded = await adminAuth.verifyIdToken(idToken);
+      const role =
+        normalizeLegacyRole(
+          decoded.role ||
+            decoded.custom_claims?.role ||
+            decoded.customClaims?.role,
+        ) || USER_ROLES.EMPLOYEE;
+
+      return NextResponse.json({
+        uid: decoded.uid,
+        email: decoded.email,
+        role,
+        companyId: decoded.companyId || decoded.custom_claims?.companyId,
+      });
+    } catch (verifyError) {
+      return NextResponse.json(
+        { error: 'Invalid or expired token' },
+        { status: 401 },
+      );
+    }
+  } catch (error) {
+    console.error('Token verification error:', error);
+    return NextResponse.json(
+      { error: 'Failed to verify token' },
+      { status: 500 },
+    );
+  }
+}

--- a/docs/auth-overview.md
+++ b/docs/auth-overview.md
@@ -1,0 +1,35 @@
+# Authentication Overview
+
+## Server (Next.js API) Endpoints
+
+- All API routes (except `/api/auth/*`) require a Firebase ID token in the
+  `Authorization: Bearer <token>` header.
+- The global `middleware.ts` verifies the token via `/api/auth/verify-token`.
+- Verified user information is forwarded to handlers through `x-user-id`,
+  `x-company-id`, and `x-user-role` headers.
+- Basic role-based restrictions are enforced:
+  - `/api/super-admin/*` → `super-admin` role required
+  - `/api/admin/*` and `/api/company-admin/*` → `company-admin` or higher
+- Route handlers may apply stricter checks using `withAuth` or the
+  `require*` helpers.
+
+## Firebase Functions
+
+- `processDocumentOnUpload` runs on Cloud Storage finalize events and processes
+  uploaded documents. It does not accept direct user requests and relies on
+  Firebase security rules for access control.
+
+## Expected Auth Flow
+
+1. Client obtains a Firebase ID token after user sign-in.
+2. Client includes `Authorization: Bearer <token>` when calling API routes.
+3. Middleware verifies the token and enforces role requirements.
+4. Pages use a session cookie (`__session`) verified via `/api/auth/verify-session`.
+
+## Required Headers
+
+- `Authorization: Bearer <Firebase ID token>` for protected API calls.
+- Middleware adds:
+  - `x-user-id` – authenticated user's UID
+  - `x-company-id` – user's company scope (if any)
+  - `x-user-role` – normalized role string

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,18 +1,25 @@
 // middleware.ts
 import { NextResponse, type NextRequest } from 'next/server';
+import { USER_ROLES, hasRoleAccess } from '@/lib/constants/roles';
 
-async function verifySession(sessionCookie: string | undefined, request: NextRequest): Promise<boolean> {
+async function verifySession(
+  sessionCookie: string | undefined,
+  request: NextRequest,
+): Promise<boolean> {
   if (!sessionCookie) {
     return false;
   }
   try {
-    const response = await fetch(new URL('/api/auth/verify-session', request.url).toString(), {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
+    const response = await fetch(
+      new URL('/api/auth/verify-session', request.url).toString(),
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ sessionCookie }),
       },
-      body: JSON.stringify({ sessionCookie }),
-    });
+    );
     const { isValid } = await response.json();
     return isValid;
   } catch (error) {
@@ -21,29 +28,98 @@ async function verifySession(sessionCookie: string | undefined, request: NextReq
   }
 }
 
+async function verifyIdToken(
+  idToken: string | undefined,
+  request: NextRequest,
+) {
+  if (!idToken) {
+    return null;
+  }
+
+  try {
+    const response = await fetch(
+      new URL('/api/auth/verify-token', request.url).toString(),
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ idToken }),
+      },
+    );
+
+    if (!response.ok) {
+      return null;
+    }
+
+    return response.json();
+  } catch (error) {
+    console.error('Middleware: Error verifying ID token.', error);
+    return null;
+  }
+}
+
 export async function middleware(request: NextRequest) {
   const session = request.cookies.get('__session');
-  const isAuthPage = request.nextUrl.pathname.startsWith('/login') || request.nextUrl.pathname.startsWith('/register');
+  const isAuthPage =
+    request.nextUrl.pathname.startsWith('/login') ||
+    request.nextUrl.pathname.startsWith('/register');
+  const isApiRoute = request.nextUrl.pathname.startsWith('/api');
   const isApiAuthRoute = request.nextUrl.pathname.startsWith('/api/auth');
 
-  // Allow API auth routes to be accessed without a session
+  // Allow API auth routes to be accessed without checks
   if (isApiAuthRoute) {
     return NextResponse.next();
   }
 
+  // API routes use ID tokens for auth
+  if (isApiRoute) {
+    const authHeader = request.headers.get('Authorization');
+    const idToken = authHeader?.split('Bearer ')[1];
+    const user = await verifyIdToken(idToken, request);
+
+    if (!user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    // Basic role-based restrictions based on path prefixes
+    const roleRequirements: Array<{ prefix: string; role: string }> = [
+      { prefix: '/api/super-admin', role: USER_ROLES.SUPER_ADMIN },
+      { prefix: '/api/admin', role: USER_ROLES.COMPANY_ADMIN },
+      { prefix: '/api/company-admin', role: USER_ROLES.COMPANY_ADMIN },
+    ];
+
+    const requiredRole = roleRequirements.find((r) =>
+      request.nextUrl.pathname.startsWith(r.prefix),
+    )?.role;
+
+    if (requiredRole && !hasRoleAccess(user.role, requiredRole)) {
+      return NextResponse.json(
+        { error: 'Insufficient permissions' },
+        { status: 403 },
+      );
+    }
+
+    const response = NextResponse.next();
+    response.headers.set('x-user-id', user.uid);
+    if (user.companyId) {
+      response.headers.set('x-company-id', user.companyId);
+    }
+    response.headers.set('x-user-role', user.role);
+    return response;
+  }
+
+  // Non-API routes use session cookies
   const sessionIsValid = await verifySession(session?.value, request);
 
-  // If the user is on an auth page but has a valid session, redirect them to the home page.
   if (sessionIsValid && isAuthPage) {
     return NextResponse.redirect(new URL('/', request.url));
   }
 
-  // If the user is on a protected page and does not have a valid session, redirect them to the login page.
   if (!sessionIsValid && !isAuthPage) {
     return NextResponse.redirect(new URL('/login', request.url));
   }
-  
-  // If none of the above, continue to the requested page.
+
   return NextResponse.next();
 }
 

--- a/tests/auth-middleware.test.ts
+++ b/tests/auth-middleware.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+import { middleware } from '../middleware';
+
+function createRequest(path: string, headers: Record<string, string> = {}) {
+  return new NextRequest(`https://example.com${path}`, {
+    headers: new Headers(headers),
+  });
+}
+
+describe('API auth middleware', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('blocks requests without Authorization header', async () => {
+    const req = createRequest('/api/admin/users');
+    const res = await middleware(req as any);
+    expect(res.status).toBe(401);
+  });
+
+  it('blocks requests with insufficient role', async () => {
+    // Mock verify-token response
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ uid: '1', role: 'employee' }),
+    }) as any;
+
+    const req = createRequest('/api/admin/users', {
+      Authorization: 'Bearer test-token',
+    });
+    const res = await middleware(req as any);
+    expect(res.status).toBe(403);
+  });
+});


### PR DESCRIPTION
## Summary
- add `/api/auth/verify-token` endpoint for Firebase ID token validation
- extend middleware to enforce ID token and basic role checks on API routes
- document authentication flow and add tests blocking unauthorized access

## Testing
- `pnpm test`
- `pnpm biome check middleware.ts app/api/auth/verify-token/route.ts docs/auth-overview.md tests/auth-middleware.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b9e8e092c48331b6feefaa64e855e4