### PR TITLE
docs: expand RAG implementation plan

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,17 @@ This is a Firebase-based Benefits Assistant Chatbot - a multi-tenant, AI-powered
 
 We are implementing a Retrieval-Augmented Generation (RAG) system to allow the chatbot to reference an internal knowledge base of benefits documents.
 
+- **Phase 1 details**:
+  - Document loading script ingests source files.
+  - Chunks and embeddings stored in Firestore.
+  - In-memory similarity search retrieves relevant content.
+- **Phase 2 upgrade steps**:
+  - Adopt Vertex AI Vector Search for scalable retrieval.
+  - Write data ingestion script to populate the index.
+  - Update retrieval logic to query the managed service.
+- **Current progress**: Phase 1 pipeline is operational with Firestore-backed storage and in-memory search.
+- **Next steps**: Stand up Vertex AI Vector Search, ingest existing embeddings, and refactor retrieval to use the new index.
+
 ### Phase 1: RAG with Firestore (In Progress)
 
 *   **Goal**: Get a functional end-to-end RAG pipeline working quickly.

--- a/claude.md
+++ b/claude.md
@@ -16,6 +16,17 @@ This is a Firebase-based Benefits Assistant Chatbot - a multi-tenant, AI-powered
 
 We are implementing a Retrieval-Augmented Generation (RAG) system to allow the chatbot to reference an internal knowledge base of benefits documents.
 
+- **Phase 1 details**:
+  - Document loading script ingests source files.
+  - Chunks and embeddings stored in Firestore.
+  - In-memory similarity search retrieves relevant content.
+- **Phase 2 upgrade steps**:
+  - Adopt Vertex AI Vector Search for scalable retrieval.
+  - Write data ingestion script to populate the index.
+  - Update retrieval logic to query the managed service.
+- **Current progress**: Phase 1 pipeline is operational with Firestore-backed storage and in-memory search.
+- **Next steps**: Stand up Vertex AI Vector Search, ingest existing embeddings, and refactor retrieval to use the new index.
+
 ### Phase 1: RAG with Firestore (In Progress)
 
 *   **Goal**: Get a functional end-to-end RAG pipeline working quickly.


### PR DESCRIPTION
## Summary
- add explicit Phase 1 details for document loading, Firestore storage, and in-memory search
- outline Phase 2 upgrade steps with Vertex AI Vector Search and retrieval refactor
- highlight current progress and next steps for RAG build-out

## Testing
- `pnpm test` *(fails: expected 307 to be 401/403)*
- `pnpm run lint` *(fails: Biome reported 233 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f1160cc883319d7652bdd5d0a9aa