### PR TITLE
docs: add tech stack section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ A multi-tenant, AI-powered benefits management platform that transforms employee
 - SSO integration
 - Analytics engine
 
+## 🛠️ Tech Stack
+
+- **Frontend**: Next.js 15, TypeScript, Tailwind CSS, shadcn/ui, SWR, etc.
+- **Backend & Infrastructure**: Firebase Auth, Firestore, Cloud Storage, Cloud Functions, Vertex AI, fallback LLMs, vector search, email, caching.
+- **Development Tools**: Biome for lint/format, Vitest/React Testing Library/Playwright, Firebase CLI, pnpm.
+
 ## 📚 Documentation
 
 ### Core Documents


### PR DESCRIPTION
## Summary
- document frontend, backend, and tooling in a new "Tech Stack" section

## Testing
- `pnpm lint` *(fails: formatter would update unrelated files)*
- `pnpm test` *(fails: API auth middleware test and others)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f11861d48331a36273438baa588b