### PR TITLE
feat: notify on document processing

### DIFF
--- a/lib/documents/processor.ts
+++ b/lib/documents/processor.ts
@@ -2,12 +2,14 @@ import { extractText } from 'unpdf';
 import { adminDb, FieldValue as AdminFieldValue } from '@/lib/firebase/admin';
 import { vectorSearchService, upsertDocumentChunks } from '@/lib/ai/vector-search';
 import { generateEmbeddings } from '@/lib/ai/embeddings';
+import { notificationService } from '@/lib/services/notification.service';
 
 
 /**
  * Process a document: extract text, chunk it, generate embeddings, and store in Vertex AI Vector Search
  */
 export async function processDocument(documentId: string) {
+  let document: any;
   try {
     // Fetch document from Firestore
     const docRef = await adminDb.collection('documents').doc(documentId).get();
@@ -16,7 +18,7 @@ export async function processDocument(documentId: string) {
       throw new Error('Document not found');
     }
 
-    const document = { id: docRef.id, ...docRef.data() } as any;
+    document = { id: docRef.id, ...docRef.data() } as any;
 
     if (!document.fileUrl) {
       throw new Error('Document has no file URL');
@@ -94,15 +96,14 @@ export async function processDocument(documentId: string) {
       chunksCount: chunks.length,
     });
 
-    // TODO: Implement document processing notifications
     // Send success notification if the document has an associated user
-    // if (document.createdBy) {
-    //   await notificationService.sendDocumentProcessedNotification({
-    //     userId: document.createdBy,
-    //     documentName: document.title,
-    //     status: 'processed',
-    //   });
-    // }
+    if (document.createdBy) {
+      await notificationService.sendDocumentProcessedNotification({
+        userId: document.createdBy,
+        documentName: document.title,
+        status: 'processed',
+      });
+    }
 
     return {
       success: upsertStatus === 'success',
@@ -124,6 +125,20 @@ export async function processDocument(documentId: string) {
         });
     } catch (updateError) {
       console.error('Failed to update document status:', updateError);
+    }
+
+    // Notify user of failure if we have creator information
+    if (document?.createdBy) {
+      try {
+        await notificationService.sendDocumentProcessedNotification({
+          userId: document.createdBy,
+          documentName: document.title,
+          status: 'failed',
+          errorMessage: error instanceof Error ? error.message : undefined,
+        });
+      } catch (notifyError) {
+        console.error('Failed to send failure notification:', notifyError);
+      }
     }
 
     throw error;

--- a/tests/document-processor.test.ts
+++ b/tests/document-processor.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+var updateMock: any;
+var docGetMock: any;
+var notifyMock: any;
+
+vi.mock('@/lib/firebase/admin', () => {
+  updateMock = vi.fn();
+  docGetMock = vi.fn();
+  return {
+    adminDb: {
+      collection: () => ({
+        doc: () => ({ get: docGetMock, update: updateMock }),
+      }),
+    },
+    FieldValue: { serverTimestamp: () => 'timestamp' },
+  };
+});
+
+vi.mock('@/lib/ai/embeddings', () => ({
+  generateEmbeddings: vi.fn(async (chunks: string[]) => chunks.map(() => [0])),
+}));
+
+vi.mock('@/lib/ai/vector-search', () => ({
+  upsertDocumentChunks: vi.fn(async () => ({ status: 'success', vectorsUpserted: 1 })),
+  vectorSearchService: {},
+}));
+
+vi.mock('@/lib/services/notification.service', () => {
+  notifyMock = vi.fn();
+  return {
+    notificationService: { sendDocumentProcessedNotification: notifyMock },
+  };
+});
+
+beforeEach(() => {
+  (global as any).fetch = vi.fn(async () => ({
+    ok: true,
+    arrayBuffer: async () => new TextEncoder().encode('hello world').buffer,
+  }));
+  updateMock.mockReset();
+  docGetMock.mockReset();
+  notifyMock.mockReset();
+});
+
+import { processDocument } from '@/lib/documents/processor';
+import { generateEmbeddings } from '@/lib/ai/embeddings';
+import { notificationService } from '@/lib/services/notification.service';
+
+describe('processDocument notifications', () => {
+  beforeEach(() => {
+    docGetMock.mockResolvedValue({
+      exists: true,
+      id: 'doc1',
+      data: () => ({
+        fileUrl: 'http://example.com/file.txt',
+        fileType: 'text/plain',
+        companyId: 'comp1',
+        title: 'Test Document',
+        createdBy: 'user1',
+      }),
+    });
+  });
+
+  it('sends success notification when document is processed', async () => {
+    await processDocument('doc1');
+    expect(notificationService.sendDocumentProcessedNotification).toHaveBeenCalledWith({
+      userId: 'user1',
+      documentName: 'Test Document',
+      status: 'processed',
+    });
+  });
+
+  it('sends failure notification when processing fails', async () => {
+    (generateEmbeddings as any).mockRejectedValueOnce(new Error('embedding fail'));
+    await expect(processDocument('doc1')).rejects.toThrow('embedding fail');
+    expect(notificationService.sendDocumentProcessedNotification).toHaveBeenCalledWith({
+      userId: 'user1',
+      documentName: 'Test Document',
+      status: 'failed',
+      errorMessage: 'embedding fail',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add document processing notification flow
- send email/in-app notices via notification service
- cover success and failure flows with tests

## Testing
- `pnpm test` *(fails: tests/auth-middleware.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68ba1433aacc833181c4917361cf366c