### PR TITLE
feat: tighten RAG search context

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -52,13 +52,12 @@ export async function POST(request: NextRequest) {
         'RAG search results:',
         searchResults.map((r) => ({
           chunkId: r.chunk.id,
-          documentId: r.chunk.documentId,
           score: r.score,
         })),
       );
     }
-    const systemPrompt = context
-      ? `Context:\n${context}\n\n${CHAT_SYSTEM_PROMPT}`
+    const systemPrompt = searchResults.length
+      ? `${CHAT_SYSTEM_PROMPT}\n\nRetrieved context:\n${context}`
       : CHAT_SYSTEM_PROMPT;
 
     // Call the Google AI model

--- a/lib/ai/rag-system.ts
+++ b/lib/ai/rag-system.ts
@@ -60,7 +60,7 @@ class RAGSystem {
   async search(
     query: string, 
     companyId: string, 
-    limit: number = 5
+    limit = 5
   ): Promise<SearchResult[]> {
     try {
       const queryEmbedding = await generateEmbedding(query);
@@ -72,30 +72,40 @@ class RAGSystem {
   }
 
   private async vectorSearch(
-    queryEmbedding: number[], 
-    companyId: string, 
+    queryEmbedding: number[],
+    companyId: string,
     limit: number
   ): Promise<SearchResult[]> {
-    const neighbors = await vectorSearchService.findNearestNeighbors(queryEmbedding, limit);
+    const neighbors = await vectorSearchService.findNearestNeighbors(
+      queryEmbedding,
+      limit,
+      companyId,
+    );
     if (!neighbors || neighbors.length === 0) {
       return [];
     }
-  
-    const chunkIds = neighbors.map(n => n.datapoint.datapointId);
-    
-    // Fetch chunk content from Firestore based on IDs from vector search
-    const chunkDocs = await adminDb.collection('document_chunks').where('id', 'in', chunkIds).get();
-    
+
+    const chunkIds = neighbors.map((n) => n.datapoint.datapointId);
+
+    // Fetch chunk content from Firestore scoped to company
+    const chunkDocs = await adminDb
+      .collection('document_chunks')
+      .where('companyId', '==', companyId)
+      .where('id', 'in', chunkIds)
+      .get();
+
     const chunksById = new Map();
-    chunkDocs.forEach(doc => chunksById.set(doc.id, doc.data()));
-    
-    return neighbors.map(neighbor => {
-      const chunk = chunksById.get(neighbor.datapoint.datapointId);
-      return {
-        chunk,
-        score: neighbor.distance, // Vertex AI returns distance, can be converted to similarity
-      };
-    }).filter(result => result.chunk && result.chunk.companyId === companyId);
+    chunkDocs.forEach((doc) => chunksById.set(doc.id, doc.data()));
+
+    return neighbors
+      .map((neighbor) => {
+        const chunk = chunksById.get(neighbor.datapoint.datapointId);
+        return {
+          chunk,
+          score: neighbor.distance, // Vertex AI returns distance, can be converted to similarity
+        };
+      })
+      .filter((result) => result.chunk && result.chunk.companyId === companyId);
   }
 
   // ... (keywordSearch, splitIntoChunks, cosineSimilarity, generateContext remain the same)

--- a/lib/ai/vector-search.ts
+++ b/lib/ai/vector-search.ts
@@ -120,17 +120,25 @@ class VectorSearchService {
     }
   }
 
-  async findNearestNeighbors(queryEmbedding: number[], numNeighbors = 5) {
+  async findNearestNeighbors(
+    queryEmbedding: number[],
+    numNeighbors = 5,
+    companyId?: string,
+  ) {
+    const query: any = {
+      datapoint: {
+        featureVector: queryEmbedding,
+      },
+      neighborCount: numNeighbors,
+    };
+
+    if (companyId) {
+      query.restricts = [{ namespace: 'company_id', allowTokens: [companyId] }];
+    }
+
     const request = {
       indexEndpoint: this.endpointPath,
-      queries: [
-        {
-          datapoint: {
-            featureVector: queryEmbedding,
-          },
-          neighborCount: numNeighbors,
-        },
-      ],
+      queries: [query],
     };
 
     try {


### PR DESCRIPTION
## Summary
- filter RAG vector search by company and scope Firestore chunk lookup
- append retrieved chunk text to system prompt and log chunk IDs with scores
- pass company restricts to Vertex AI neighbor queries

## Testing
- `pnpm lint` *(fails: The number of diagnostics exceeds the number allowed by Biome.)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9ea5961fc8331815feb4bf2543fa7